### PR TITLE
modify get_latency_lookup_table.py to make it compatible for python2 and python3

### DIFF
--- a/PaddleSlim/docs/usage.md
+++ b/PaddleSlim/docs/usage.md
@@ -676,6 +676,7 @@ controllers:
     Android 系统:
 
     - 用户从[这里](https://paddle-slim-models.bj.bcebos.com/Android_demo.zip)下载 Android 系统的延时评估器生成工具。
+    - 安装ADB。比如 macOS 系统, 可以利用brew一键安装，`brew cask install android-platform-tools`。
     - 连接硬件平台。利用 adb devices 查看当前连接的设备，判断是否正确连接。
     - 进入工具目录 Android_demo，命令行输入 `sh push2android.sh`, 把必要的文件放置到硬件平台。
     - 在 `models/PaddleSlim/light_nas/` 目录下运行 `python get_latency_lookup_table.py` 就可以获取当前搜索空间的延时评估器表格 `latency_lookup_table.txt`。
@@ -699,11 +700,11 @@ controllers:
 
     - `./get_net_latency model_path threads test_iter`
 
-    其中 `model_path` 是保存 PaddlePaddle 模型的路径，用户需要利用 [paddle.fluid.io.save_inference_model](https://www.paddlepaddle.org.cn/documentation/docs/zh/1.5/api_cn/io_cn.html#save-inference-model)将参数保存为单独的文件。如何单独使用这些二进制文件可以参看[这里](https://github.com/PaddlePaddle/paddle-mobile/blob/develop/doc/development_android.md)或者`get_latency_lookup_table.py`里面的类似方法。
+    其中 `model_path` 是保存 PaddlePaddle 模型的路径，用户需要利用 [paddle.fluid.io.save_inference_model](https://www.paddlepaddle.org.cn/documentation/docs/zh/1.5/api_cn/io_cn.html#save-inference-model)将参数保存为单独的文件。如何单独使用这些二进制文件可以参看[这里](https://github.com/PaddlePaddle/Paddle-Lite/blob/develop/mobile/doc/development_android.md)或者`get_latency_lookup_table.py`里面的类似方法。
 
-    备注2：用户如果有其他 op 的开发需求，可以根据 Paddle Mobile 的[op单测](https://github.com/PaddlePaddle/paddle-mobile/tree/develop/test/operators)进行开发，基于android端的编译方法可以参见[这里](https://github.com/PaddlePaddle/paddle-mobile/blob/develop/doc/development_android.md)，欢迎大家贡献代码。
+    备注2：用户如果有其他 op 的开发需求，可以根据 Paddle Mobile 的[op单测](https://github.com/PaddlePaddle/Paddle-Lite/tree/develop/mobile/test/operators)进行开发，基于android端的编译方法可以参见[这里](https://github.com/PaddlePaddle/Paddle-Lite/blob/develop/mobile/doc/development_android.md)，欢迎大家贡献代码。
 
-    我们提供的示例 op 的单测代码可以在[这里](https://paddle-slim-models.bj.bcebos.com/android_op_test.zip)下载。用户通过 `git clone https://github.com/PaddlePaddle/paddle-mobile.git` 命令, 将 android_op_test 里面的单测代码放置到 `paddle-mobile/test/operators` 目录，然后修改 `paddle-mobile/test/CMakeList.txt` 进行编译即可生成所需的二进制文件。
+    我们提供的示例 op 的单测代码可以在[这里](https://paddle-slim-models.bj.bcebos.com/android_op_test.zip)下载。用户通过 `git clone https://github.com/PaddlePaddle/Paddle-Lite.git` 命令, 将 android_op_test 里面的单测代码放置到 `Paddle-Lite/mobile/test/operators` 目录，然后修改 `Paddle-Lite/mobile/test/CMakeList.txt` 进行编译即可生成所需的二进制文件。
 
     iOS系统：
 

--- a/PaddleSlim/light_nas/get_latency_lookup_table.py
+++ b/PaddleSlim/light_nas/get_latency_lookup_table.py
@@ -63,7 +63,7 @@ def get_op_latency(op, platform):
             stderr=subprocess.PIPE,
             shell=True)
         out = proc.communicate()[0]
-        out = [_ for _ in out.split('\n') if 'Latency' in _][-1]
+        out = [_ for _ in out.decode().split('\n') if 'Latency' in _][-1]
         out = re.findall(r'\d+\.?\d*', out)[0]
         out = float(out)
     elif platform == 'ios':


### PR DESCRIPTION
1. modify get_latency_lookup_table.py to make it compatible for python2 and python3
2. modify usage.md to update the information of PaddleMobile to Paddle-Lite